### PR TITLE
Fix recommendation visibility

### DIFF
--- a/src/components/RecommendationSection.jsx
+++ b/src/components/RecommendationSection.jsx
@@ -1,7 +1,14 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 function RecommendationSection({ recommendations }) {
   const [showRecommendations, setShowRecommendations] = useState(false);
+
+  // Automatically show recommendations when new data is provided
+  useEffect(() => {
+    if (recommendations && recommendations.length > 0) {
+      setShowRecommendations(true);
+    }
+  }, [recommendations]);
 
   const handleToggleRecommendations = () => {
     setShowRecommendations(!showRecommendations);


### PR DESCRIPTION
## Summary
- show recommendations automatically when data is loaded

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68756dc119908329b1930a6c3cd1bb1a